### PR TITLE
Fix infinite loop on MacOS

### DIFF
--- a/predicates.h
+++ b/predicates.h
@@ -286,22 +286,26 @@ namespace detail {
 	};
 
 	//std::fma is faster than dekker's product when the processor instruction is available
+	//NOTE(rgriege): Due to potential bugs in the non-fma implementation (see comment at
+	//the attempted re-define of FP_FAST_FMAF), run fma even when it's slow.  Clang will
+	//generate the fast version even though these macros aren't defined depending on the
+	//compiler flags. I was able to do it on Godbolt using -mfma.
 	#ifdef FP_FAST_FMAF
 		static const bool fp_fast_fmaf = true;
 	#else
-		static const bool fp_fast_fmaf = false;
+		static const bool fp_fast_fmaf = true;
 	#endif
 
 	#ifdef FP_FAST_FMA
 		static const bool fp_fast_fma = true;
 	#else
-		static const bool fp_fast_fma = false;
+		static const bool fp_fast_fma = true;
 	#endif
 
 	#ifdef FP_FAST_FMAL
 		static const bool fp_fast_fmal = true;
 	#else
-		static const bool fp_fast_fmal = false;
+		static const bool fp_fast_fmal = true;
 	#endif
 
 	#ifdef _PREDICATES_CXX11_IS_SUPPORTED


### PR DESCRIPTION
We're getting numerical differences on MacOS vs other platforms, and this can cause an infinite loop in parts of the library.  Using std::fma seems to fix the differences.  I fought clang for a while to make it define the FP_FAST_FMA* macros, but I failed.  As noted in the comment, I confirmed in a Godbolt session that passing -mfma would still use the intrinsic version.

```
float func(float a, float b) {
	return std::fmaf(a, b, 3);
}

#ifndef FP_FAST_FMAF
#error "Fast FMA operation not supported"
#endif
```

Compiling with `clang -mfma` will trigger the `#error` statement but will produce a `vfmadd213ss` call if you remove the `FP_FAST_FMAF` check.

This commit leaves the code in a weird spot, but I'm avoiding a deeper change so we don't run into issue pulling in any new upstream changes.