### PR TITLE
Update predicates

### DIFF
--- a/predicates.h
+++ b/predicates.h
@@ -404,6 +404,7 @@ namespace detail {
 			static T MultTail(const T a, const T b, const T p) {return std::fma(a, b, -p);}
 			static T MultTailPreSplit(const T a, const T b, const std::pair<T, T> /*bSplit*/, const T p) {return std::fma(a, b, -p);}
 #else
+#error "These operations produce different results and can cause infinite loops."
 			static T MultTail(const T a, const T b, const T p) {return DekkersProduct(a, Split(a), b, Split(b), p);}
 			static T MultTailPreSplit(const T a, const T b, const std::pair<T, T> bSplit, const T p) {return DekkersProduct(a, Split(a), b, bSplit, p);}
 #endif


### PR DESCRIPTION
Integrate some changes from https://github.com/artem-ogre/CDT for FMA detection so that we can enable it on clang and fix an infinite loop in the MacOS build.  That repo also changes some epsilon values, but I am not smart enough to know which set is better.